### PR TITLE
enhance(PressableButtonStyle): add iOS 26 glass effect and rectRadius initializer

### DIFF
--- a/Composable SwiftUI/Common/Components/ButtonView.swift
+++ b/Composable SwiftUI/Common/Components/ButtonView.swift
@@ -37,7 +37,7 @@ struct ButtonView: View {
                     .stroke(Color.black.opacity(0.2), lineWidth: 2)
             )
         }
-//        .buttonStyle(PressableButtonStyle())
+        .buttonStyle(PressableButtonStyle())
     }
 }
 

--- a/Composable SwiftUI/Common/Components/EpisodeCarouselView.swift
+++ b/Composable SwiftUI/Common/Components/EpisodeCarouselView.swift
@@ -41,9 +41,9 @@ struct EpisodeCarouselView: View {
                                     .aspectRatio(1, contentMode: .fill)
                                     .frame(width: 150, height: 150)
                                     .clipped()
-                                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.m, style: .continuous))
                             }
-                            .buttonStyle(PressableButtonStyle())
+                            .buttonStyle(PressableButtonStyle(rectRadius: Theme.Radius.m))
 
                             Text(episode.name)
                                 .bodyStyle()
@@ -56,7 +56,7 @@ struct EpisodeCarouselView: View {
                         Button(action: onSeeAll) {
                             VStack {
                                 ZStack {
-                                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                    RoundedRectangle(cornerRadius: Theme.Radius.m, style: .continuous)
                                         .fill(Color.gray.opacity(0.2))
                                         .frame(width: 150, height: 150)
 
@@ -66,9 +66,9 @@ struct EpisodeCarouselView: View {
                                 }
                             }
                             .frame(width: 150)
-                            .padding(.trailing, 28)
                         }
-                        .buttonStyle(PressableButtonStyle())
+                        .buttonStyle(PressableButtonStyle(rectRadius: Theme.Radius.m))
+                        .padding(.trailing, 28)
                     }
                 }
                 .padding(.horizontal)

--- a/Composable SwiftUI/Common/Modifiers/PressableButtonStyle.swift
+++ b/Composable SwiftUI/Common/Modifiers/PressableButtonStyle.swift
@@ -3,28 +3,49 @@ import SwiftUI
 struct PressableButtonStyle: ButtonStyle {
 
     @State private var isAnimating = false
+    let glassShape: AnyShape?
+
+    init(glassShape: AnyShape? = nil) {
+        self.glassShape = glassShape
+    }
 
     func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .scaleEffect(configuration.isPressed || isAnimating ? 0.93 : 1.0)
-            .animation(.spring(response: 0.30, dampingFraction: 0.45), value: configuration.isPressed || isAnimating)
-            .simultaneousGesture(
-                TapGesture()
-                    .onEnded { _ in
-                        triggerTapAnimation()
-                    }
-            )
+        if #available(iOS 26, *) {
+            if let glassShape {
+                configuration.label
+                    .glassEffect(.regular.interactive(), in: glassShape)
+            } else {
+                configuration.label
+                    .glassEffect(.regular.interactive())
+            }
+        } else {
+            configuration.label
+                .scaleEffect(configuration.isPressed || isAnimating ? 0.93 : 1.0)
+                .animation(.spring(response: 0.30, dampingFraction: 0.45), value: configuration.isPressed || isAnimating)
+                .simultaneousGesture(
+                    TapGesture()
+                        .onEnded { _ in
+                            triggerTapAnimation()
+                        }
+                )
+        }
     }
 
     private func triggerTapAnimation() {
         withAnimation(.spring(response: 0.30, dampingFraction: 0.45)) {
             isAnimating = true
         }
-
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             withAnimation(.spring(response: 0.30, dampingFraction: 0.45)) {
                 isAnimating = false
             }
         }
+    }
+}
+
+extension PressableButtonStyle {
+
+    init(rectRadius: CGFloat) {
+        self.glassShape = AnyShape(.rect(cornerRadius: rectRadius))
     }
 }

--- a/Composable SwiftUI/Scenes/EpisodesList/EpisodesListView.swift
+++ b/Composable SwiftUI/Scenes/EpisodesList/EpisodesListView.swift
@@ -75,7 +75,7 @@ private struct EpisodesList: View {
                                 }
                             }
                     }
-                    .buttonStyle(PressableButtonStyle())
+                    .buttonStyle(PressableButtonStyle(rectRadius: Theme.Radius.m))
                 }
 
                 if isLoading {

--- a/Composable SwiftUI/Scenes/Main/MainView.swift
+++ b/Composable SwiftUI/Scenes/Main/MainView.swift
@@ -94,6 +94,7 @@ struct MainView: View {
 //            }
         }
 //        .searchable(text: $searchText, prompt: "Search...")
+        .tint(Theme.Colors.primary)
         .environment(mainCoordinator)
         .environment(charactersCoordinator)
         .environment(episodesCoordinator)


### PR DESCRIPTION
## Summary
- Adds support for `glassEffect` in iOS 26+ to `PressableButtonStyle`
- Adds new `init(rectRadius:)` initializer for easier configuration
- Updates components to use `Theme.Radius.m` for consistency
## Changes
- **PressableButtonStyle.swift**: New `glassShape` property with iOS 26 availability check, new `init(rectRadius:)` convenience initializer
- **EpisodeCarouselView.swift**: Uses `Theme.Radius.m` and new `PressableButtonStyle(rectRadius:)` 
- **EpisodesListView.swift**: Uses new `PressableButtonStyle(rectRadius:)`
- **ButtonView.swift**: Activates `PressableButtonStyle()`
## Testing
- Verified lint passes with 0 violations