### PR TITLE
test(episodes-list): add EpisodesListReducer tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Summary
+
+One or two sentences describing what this PR does and why. Link the issue: `Fixes #` or `Relates to #`.
+
+## How
+
+High-level approach. For trivial changes, a one-liner is fine.
+
+## Testing
+
+- [ ] Full test suite: `xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`
+- [ ] Targeted tests: `xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:"Composable SwiftUITests/<SuiteName>" test`
+- [ ] Strict lint passes: `swiftlint --strict`
+- [ ] New or updated tests written
+
+## Risk & Rollback
+
+What could break and how to revert. If this PR is safe to roll back by reverting the merge commit, say so.
+
+## Checklist
+
+- [ ] Conventional Commits — commits are structured as `type(scope): subject`
+- [ ] Work units — each commit is a reviewable logical unit (tests + code + docs stay together)
+- [ ] Swift 6 language mode clean — no `@unchecked Sendable`, no `@preconcurrency`
+- [ ] User-facing copy in `Composable SwiftUI/Resources/en.lproj/Localizable.strings` if applicable
+- [ ] PR under 400 changed lines, or split into chained PRs
+- [ ] Architecture boundaries preserved: Scenes → Business ← Data (no downward dependencies)
+
+## Screenshots / Recordings
+
+<!-- Drag or paste screenshots here. For UI changes, include before/after. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,18 +24,18 @@ Run from repository root.
 
 Build app:
 ```bash
-xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUI" -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build
+xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUI" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
 ```
 
 Build tests target/scheme:
 ```bash
-xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build
+xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
 ```
 
 ## Test Commands
 Run all tests with xcodebuild:
 ```bash
-xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 16 Pro' test
+xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
 ```
 
 Run all tests with Fastlane:
@@ -51,12 +51,12 @@ DEVICE='iPhone 17 Pro (26.5)' bundle exec fastlane test
 ### Run a Single Test (important)
 Run one test method:
 ```bash
-xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:"Composable SwiftUITests/CharactersListReducerTests/getCharactersSuccess" test
+xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:"Composable SwiftUITests/CharactersListReducerTests/getCharactersSuccess" test
 ```
 
 Run one test type/file:
 ```bash
-xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:"Composable SwiftUITests/CharactersListReducerTests" test
+xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:"Composable SwiftUITests/CharactersListReducerTests" test
 ```
 
 Guidance:

--- a/Composable SwiftUI.xcodeproj/project.pbxproj
+++ b/Composable SwiftUI.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		5A1B00052E40000100ABC001 /* GetLocationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1B000A2E40000100ABC001 /* GetLocationsResponse.swift */; };
 		5A1C00012E40000100ABC001 /* LocationsListReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1C00022E40000100ABC001 /* LocationsListReducerTests.swift */; };
 		5A1C00032E40000100ABC001 /* GetLocationsInteractorDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1C00042E40000100ABC001 /* GetLocationsInteractorDefaultTests.swift */; };
+		5A1C00052E40000100ABC001 /* EpisodesListReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1C00062E40000100ABC001 /* EpisodesListReducerTests.swift */; };
 		5A1D00012E40000100ABC001 /* LocationsListViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1D00022E40000100ABC001 /* LocationsListViewTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -338,6 +339,7 @@
 		5A1B000A2E40000100ABC001 /* GetLocationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetLocationsResponse.swift; sourceTree = "<group>"; };
 		5A1C00022E40000100ABC001 /* LocationsListReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationsListReducerTests.swift; sourceTree = "<group>"; };
 		5A1C00042E40000100ABC001 /* GetLocationsInteractorDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetLocationsInteractorDefaultTests.swift; sourceTree = "<group>"; };
+		5A1C00062E40000100ABC001 /* EpisodesListReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodesListReducerTests.swift; sourceTree = "<group>"; };
 		5A1D00022E40000100ABC001 /* LocationsListViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationsListViewTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -842,6 +844,7 @@
 				49529CA72A784C49002F7594 /* CharacterNeighborsReducerTests.swift */,
 				49E4F844284AA46F0037FD72 /* CharactersListReducerTests.swift */,
 				5A1C00022E40000100ABC001 /* LocationsListReducerTests.swift */,
+				5A1C00062E40000100ABC001 /* EpisodesListReducerTests.swift */,
 				49E4F846284FBD900037FD72 /* MatchBuddyReducerTests.swift */,
 			);
 			path = Reducers;
@@ -1319,6 +1322,7 @@
 				49E4F847284FBD910037FD72 /* MatchBuddyReducerTests.swift in Sources */,
 				49E4F845284AA46F0037FD72 /* CharactersListReducerTests.swift in Sources */,
 				5A1C00012E40000100ABC001 /* LocationsListReducerTests.swift in Sources */,
+				5A1C00052E40000100ABC001 /* EpisodesListReducerTests.swift in Sources */,
 				49529CA82A784C49002F7594 /* CharacterNeighborsReducerTests.swift in Sources */,
 				4976B3692C99CC6000531ADE /* Tags.swift in Sources */,
 				498BEF7C28535649003A3131 /* EpisodesRepositoryDefaultTests.swift in Sources */,

--- a/Composable SwiftUITests/Reducers/EpisodesListReducerTests.swift
+++ b/Composable SwiftUITests/Reducers/EpisodesListReducerTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+import ComposableArchitecture
+import Mockable
+@testable import Composable_SwiftUI
+
+@Suite(
+    "EpisodesListReducer",
+    .tags(.reducer)
+)
+struct EpisodesListReducerTests {
+
+    @Test
+    func onAppearSuccess() async {
+        let mockInteractor = MockGetEpisodesInteractor()
+        let mockResponse = [Episode.mock]
+        let store = await TestStore(
+            initialState: EpisodesListReducer.State(),
+            reducer: {
+                EpisodesListReducer(getEpisodesInteractor: mockInteractor)
+            }
+        )
+
+        given(mockInteractor)
+            .execute()
+            .willReturn(mockResponse)
+
+        await store.send(.onAppear)
+
+        await store.receive(\.getEpisodes) {
+            $0.episodes.state = .loading
+        }
+
+        await store.receive(\.onReceiveEpisodes.success) {
+            $0.episodes.state = .populated(data: mockResponse)
+        }
+
+        verify(mockInteractor)
+            .execute()
+            .called(.once)
+
+        verify(mockInteractor)
+            .execute(id: .any)
+            .called(.never)
+
+        verify(mockInteractor)
+            .execute(ids: .any)
+            .called(.never)
+    }
+
+    @Test
+    func getMoreEpisodesSuccessAndAppend() async {
+        let mockInteractor = MockGetEpisodesInteractor()
+        let initialEpisodes = Episode.mocks
+        let newEpisodes = [Episode.mock]
+        var initialState = EpisodesListReducer.State()
+        initialState.episodes.state = .populated(data: initialEpisodes)
+
+        let store = await TestStore(
+            initialState: initialState,
+            reducer: {
+                EpisodesListReducer(getEpisodesInteractor: mockInteractor)
+            }
+        )
+
+        given(mockInteractor)
+            .execute()
+            .willReturn(newEpisodes)
+
+        await store.send(.getMoreEpisodes)
+
+        await store.receive(\.getEpisodes) {
+            $0.episodes.state = .loading
+        }
+
+        await store.receive(\.onReceiveEpisodes.success) {
+            $0.episodes.state = .populated(data: initialEpisodes + newEpisodes)
+        }
+
+        verify(mockInteractor)
+            .execute()
+            .called(.once)
+
+        verify(mockInteractor)
+            .execute(id: .any)
+            .called(.never)
+
+        verify(mockInteractor)
+            .execute(ids: .any)
+            .called(.never)
+    }
+
+    @Test
+    func onAppearFail() async {
+        let mockInteractor = MockGetEpisodesInteractor()
+        let mockError = InteractorError.generic(message: "mock error")
+        let store = await TestStore(
+            initialState: EpisodesListReducer.State(),
+            reducer: {
+                EpisodesListReducer(getEpisodesInteractor: mockInteractor)
+            }
+        )
+
+        given(mockInteractor)
+            .execute()
+            .willThrow(mockError)
+
+        await store.send(.onAppear)
+
+        await store.receive(\.getEpisodes) {
+            $0.episodes.state = .loading
+        }
+
+        await store.receive(\.onReceiveEpisodes.failure) {
+            $0.episodes.state = .error(mockError)
+        }
+
+        verify(mockInteractor)
+            .execute()
+            .called(.once)
+
+        verify(mockInteractor)
+            .execute(id: .any)
+            .called(.never)
+
+        verify(mockInteractor)
+            .execute(ids: .any)
+            .called(.never)
+    }
+}


### PR DESCRIPTION
## Summary

Adds `TestStore` coverage for `EpisodesListReducer` (onAppear success, pagination append, failure) mirroring the existing `LocationsListReducerTests` style. Also syncs the `AGENTS.md` simulator reference with the CI device and adds the project's GitHub PR template.

## How

- New `EpisodesListReducerTests.swift` with 3 tests following the suite patterns of `LocationsListReducerTests` (Mockable mocks + TestStore + Swift Testing `.reducer` tag).
- Registered the new test file in `project.pbxproj` (the project uses explicit file references).
- `AGENTS.md`: updated `iPhone 16 Pro` → `iPhone 17 Pro` to match CI (`runTests.yml`).
- Added `.github/PULL_REQUEST_TEMPLATE.md` adapted to this project's iOS-only workflow.

## Testing

- [ ] Full test suite: `xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`
- [x] Targeted tests: `xcodebuild -project "Composable SwiftUI.xcodeproj" -scheme "Composable SwiftUITests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:"Composable SwiftUITests/EpisodesListReducerTests" test`
- [x] Strict lint passes: `swiftlint --strict`
- [x] New or updated tests written

## Risk & Rollback

Tests, docs and CI metadata only; no runtime behavior changes. Safe to roll back by reverting the merge commit.

## Checklist

- [x] Conventional Commits — commits are structured as `type(scope): subject`
- [x] Work units — each commit is a reviewable logical unit (tests + code + docs stay together)
- [x] Swift 6 language mode clean — no `@unchecked Sendable`, no `@preconcurrency`
- [x] User-facing copy in `Composable SwiftUI/Resources/en.lproj/Localizable.strings` if applicable (N/A — no UI changes)
- [x] PR under 400 changed lines, or split into chained PRs (170 lines)
- [x] Architecture boundaries preserved: Scenes → Business ← Data (no downward dependencies)

## Screenshots / Recordings

No UI changes.